### PR TITLE
Fix werkzeug issue with Python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask==1.0.2
 itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.1
-Werkzeug==0.15.2
+Werkzeug==0.15.5


### PR DESCRIPTION
Per [this issue](https://github.com/pallets/werkzeug/issues/1551), werkzeug 0.15.4 and earlier have an incompatibility with Python 3.8.x. Bumping the version to `0.15.5` resolved this problem.